### PR TITLE
To fix test fail when running test using "Test Runner for Java" VS Co…

### DIFF
--- a/Vox-Viridis/src/test/java/com/example/Vox/Viridis/VoxViridisApplicationTests.java
+++ b/Vox-Viridis/src/test/java/com/example/Vox/Viridis/VoxViridisApplicationTests.java
@@ -2,8 +2,9 @@ package com.example.Vox.Viridis;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class VoxViridisApplicationTests {
 
 	@Test

--- a/Vox-Viridis/src/test/java/com/example/Vox/Viridis/service/MailServiceTest.java
+++ b/Vox-Viridis/src/test/java/com/example/Vox/Viridis/service/MailServiceTest.java
@@ -6,9 +6,10 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.mail.SimpleMailMessage;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class MailServiceTest {
 
     @Mock


### PR DESCRIPTION
…de extension

not sure why it works when running ./mvnw test but not through VS Code extension. But adding "webEnvironment = WebEnvironment.RANDOM_PORT" in SpringBootTest annotation fixes that issue